### PR TITLE
Use escript explicitly

### DIFF
--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -97,7 +97,7 @@ function s:ErlangFindExternalFunc(module, base)
     endif
 
     let compl_words = []
-    let functions = system(s:erlang_complete_file .
+    let functions = system('escript ' . s:erlang_complete_file .
                           \' list-functions ' . a:module .
                           \' --basedir ' .  expand('%:p:h'))
     for function_spec in split(functions, '\n')


### PR DESCRIPTION
Windows does not evaluate shebang lines, instead it will try to use a configured file handler for a given filetype. This means that any autocompletion attempt with this plugin will currently open a text editor with
the erlang_complete.erl.

This patch calls `escript` explicitly, which should work on all platforms.