### PR TITLE
Bugfix: ignore extra spurious arguments in main

### DIFF
--- a/autoload/erlang_complete.erl
+++ b/autoload/erlang_complete.erl
@@ -13,9 +13,9 @@ main([]) ->
 main(Args) ->
     PositionalParams = parse_args(Args),
     case PositionalParams of
-        ["list-modules"] ->
+        ["list-modules"|_] ->
             run(list_modules);
-        ["list-functions", ModuleString] ->
+        ["list-functions", ModuleString|_] ->
             run({list_functions, list_to_atom(ModuleString)});
         _ ->
             log_error("Erroneous parameters: ~p", [PositionalParams]),


### PR DESCRIPTION
I discoverd a weird behaviour on the very first usage of this plugin (call me lucky...). My installation is vim 8.0 on Arch Linux, full `vim --version` details [here](https://github.com/vim-erlang/vim-erlang-omnicomplete/files/611547/vim_version.txt).
Apparently, if the path to the file opened in vim contains some white spaces, the main function in `autoload/erlang_complete.erl` receives extra trailing positional arguments (which are the pieces of path following  those spaces).

I do not know exactly why this happens, but changing the patterns this way in the main function should solve the problem, making the plugin robust against unexpected input like that (hopefully without breaking anything else).

Here there is an example, editing the file `/home/martino/Desktop/bad folder/test.erl` (notice the space in the name of the last directory):
![screenshot_20161124_155321](https://cloud.githubusercontent.com/assets/8300317/20602737/d9fc742a-b25e-11e6-8a8e-222fbd9affe0.png)
