### PR TITLE
Make edoc return more key words, also clean up cache when a file is saved.

### DIFF
--- a/autoload/erlang_complete.erl
+++ b/autoload/erlang_complete.erl
@@ -585,15 +585,14 @@ map_functions(F, [H | T]) ->
 
 analyze_function(Fun) ->
     Name = list_to_atom(get_attribute(Fun, "name")),
-    Label = get_attribute(Fun, "label"),
-    {_, [_|ArgCount]} = lists:splitwith(fun(I) -> I =/= $- end, Label),
+    Arity = get_attribute(Fun, "arity"),
     Args0 = xmerl_xpath:string("typespec/type/fun/argtypes/type", Fun),
     Args = lists:map(fun(Arg) -> get_attribute(Arg, "name") end, Args0),
     try
         Return = analyze_return(Fun),
         {Name, Args, Return}
     catch
-        throw:no_spec -> {Name, list_to_integer(ArgCount)}
+        throw:no_spec -> {Name, list_to_integer(Arity)}
     end.
 
 analyze_return(Fun) ->

--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -10,6 +10,8 @@
 " Completion program path
 let s:erlang_complete_file = expand('<sfile>:p:h') . '/erlang_complete.erl'
 
+au BufWritePre *.erl :call erlang_complete#ClearOneCace(expand('%:t:r'))
+
 if !exists('g:erlang_completion_cache')
     let g:erlang_completion_cache = 1
 endif
@@ -187,6 +189,12 @@ endfunction
 function erlang_complete#ClearAllCache()
     let s:modules_cache = {}
 endfunction
+
+function erlang_complete#ClearOneCace(mod)
+    if has_key(s:modules_cache, a:mod)
+        call remove(s:modules_cache, a:mod)
+    endif
+endfunc
 
 " This list comes from http://www.erlang.org/doc/man/erlang.html (minor
 " modifications have been performed).


### PR DESCRIPTION
I think edoc is good to generate newest keywords for external functions before you compile `.erl` to `.beam` , so I do some change on this to make it possible to return non-spec functions from edoc. It works on my laptop using erlang 19. But I am not sure if it works fine on other versions. Please do some review and let me know what have i missed.