### PR TITLE
Add preview, and some other little change

### DIFF
--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -136,7 +136,8 @@ endfunction
 
 function s:GetFunctionNameFromEscriptOutput(function_spec)
     let pre_function_name = substitute(a:function_spec, ').*', ')', '')
-    let function_name = substitute(pre_function_name, '([^)]*', '(', '')
+    let pre_function_name_2 = substitute(pre_function_name, '\s', '', 'g')
+    let function_name = substitute(pre_function_name_2, '([^)]\+)', '(', '')
 
     let parameter_num = matchstr(function_name, '/\d\+')
     let real_function_name = substitute(function_name, '/\d\+', '', '')
@@ -164,8 +165,8 @@ function s:ErlangFindLocalFunc(base)
         let function_name_match = matchstr(buffer, '\(\.\s*\|^\)\@<='.a:base.'[0-9A-Za-z_-]\+([_a-zA-Z0-9, \t]*)\(\s*->\)\@=', 0, i)
         if function_name_match != ""
             echom function_name_match
-            let pre_function_name = substitute(function_name_match, ').*', ')', '')
-            let function_name = substitute(pre_function_name, '([^)]*', '(', '')
+            let pre_function_name = substitute(function_name_match, '\s', '', 'g')
+            let function_name = substitute(pre_function_name, '([^)]\+)', '(', '')
             echom pre_function_name
             call add(compl_words, {'word': function_name ,
                                   \'abbr': function_name, 'info': function_name_match,
@@ -186,7 +187,8 @@ function s:ErlangFindLocalFunc(base)
     for bif_line in s:auto_imported_bifs
         if bif_line =~# base
             let pre_bif_name = substitute(bif_line, ').*', ')', '')
-            let bif_name = substitute(pre_bif_name, '([^)]*', '(', '')
+            let pre_bif_name2 = substitute(pre_bif_name, '\s', '', 'g')
+            let bif_name = substitute(pre_bif_name2, '([^)]\+)', '(', '')
             call add(compl_words, {'word': bif_name,
                                    \'abbr': bif_line, 'info': bif_line,
                                    \'kind': 'f'})

--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -16,6 +16,10 @@ if !exists('g:erlang_completion_cache')
     let g:erlang_completion_cache = 1
 endif
 
+if !exists('g:erlang_complete_left_bracket')
+    let g:erlang_complete_left_bracket = 1
+endif
+
 " Modules cache used to speed up the completion
 let s:modules_cache = {}
 
@@ -137,16 +141,28 @@ endfunction
 function s:GetFunctionNameFromEscriptOutput(function_spec)
     let pre_function_name = substitute(a:function_spec, ').*', ')', '')
     let pre_function_name_2 = substitute(pre_function_name, '\s', '', 'g')
-    let function_name = substitute(pre_function_name_2, '([^)]\+)', '(', '')
+    if g:erlang_complete_left_bracket == 1
+        let function_name = substitute(pre_function_name_2, '([^)]\+)', '(', '')
+    else
+        let function_name = substitute(pre_function_name_2, '([^)]\+)', '', '')
+    endif
 
     let parameter_num = matchstr(function_name, '/\d\+')
     let real_function_name = substitute(function_name, '/\d\+', '', '')
     echom 'pre:'.pre_function_name.',function name:'.function_name.'parameter num:'.parameter_num.'real name:'.real_function_name
     if parameter_num == '/0'
-        return real_function_name. '()'
+        if g:erlang_complete_left_bracket == 1
+            return real_function_name. '()'
+        else
+            return real_function_name
+        endif
     else 
         if parameter_num != ''
-            return real_function_name . '('
+            if g:erlang_complete_left_bracket == 1
+                return real_function_name . '('
+            else
+                return real_function_name
+            endif
         else
             return real_function_name
         endif
@@ -166,7 +182,11 @@ function s:ErlangFindLocalFunc(base)
         if function_name_match != ""
             echom function_name_match
             let pre_function_name = substitute(function_name_match, '\s', '', 'g')
-            let function_name = substitute(pre_function_name, '([^)]\+)', '(', '')
+            if g:erlang_complete_left_bracket == 1
+                let function_name = substitute(pre_function_name, '([^)]\+)', '(', '')
+            else
+                let function_name = substitute(pre_function_name, '([^)]\+)', '', '')
+            endif
             echom pre_function_name
             call add(compl_words, {'word': function_name ,
                                   \'abbr': function_name, 'info': function_name_match,
@@ -188,7 +208,12 @@ function s:ErlangFindLocalFunc(base)
         if bif_line =~# base
             let pre_bif_name = substitute(bif_line, ').*', ')', '')
             let pre_bif_name2 = substitute(pre_bif_name, '\s', '', 'g')
-            let bif_name = substitute(pre_bif_name2, '([^)]\+)', '(', '')
+            if g:erlang_complete_left_bracket == 1
+                let bif_name = substitute(pre_bif_name2, '([^)]\+)', '(', '')
+            else
+                let bif_name = substitute(pre_bif_name2, '([^)]\+)', '', '')
+            endif
+
             call add(compl_words, {'word': bif_name,
                                    \'abbr': bif_line, 'info': bif_line,
                                    \'kind': 'f'})

--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -154,25 +154,27 @@ endfunction
 
 " Find local function names
 function s:ErlangFindLocalFunc(base)
-    " Begin at line 1
-    let lnum = s:ErlangFindNextNonBlank(1)
 
-    if "" == a:base
-        let base = '^\w' " Used to match against word symbol
-    else
-        let base = '^' . a:base
-    endif
+    let buffer_list = getline(1, '$')
+    let buffer = join(buffer_list, " ")
 
     let compl_words = []
-    while 0 != lnum && !complete_check()
-        let line = getline(lnum)
-        let function_name = matchstr(line, base . '[0-9A-Za-z_-]\+(\@=')
-        if function_name != ""
-            call add(compl_words, {'word': function_name . '(',
-                                  \'abbr': function_name, 'info': function_name,
+    let i = 1
+    while !complete_check()
+        let function_name_match = matchstr(buffer, '\(\.\s*\|^\)\@<='.a:base.'[0-9A-Za-z_-]\+([_a-zA-Z0-9, \t]*)\(\s*->\)\@=', 0, i)
+        if function_name_match != ""
+            echom function_name_match
+            let pre_function_name = substitute(function_name_match, ').*', ')', '')
+            let function_name = substitute(pre_function_name, '([^)]*', '(', '')
+            echom pre_function_name
+            call add(compl_words, {'word': function_name ,
+                                  \'abbr': function_name, 'info': function_name_match,
                                   \'kind': 'f'})
+        else
+            break
         endif
-        let lnum = s:ErlangFindNextNonBlank(lnum)
+
+        let i = i + 1
     endwhile
 
     if "" == a:base

--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -106,7 +106,7 @@ function s:ErlangFindExternalFunc(module, base)
         if match(function_spec, a:base) == 0
             let function_name = matchstr(function_spec, a:base . '\w*')
             let field = {'word': function_name . '(', 'abbr': function_spec,
-                  \  'kind': 'f', 'dup': 1}
+                  \  'kind': 'f', 'dup': 1, 'info': function_spec}
             call add(compl_words, field)
 
             " Populate the cache only when iterating over all the
@@ -151,7 +151,7 @@ function s:ErlangFindLocalFunc(base)
         let function_name = matchstr(line, base . '[0-9A-Za-z_-]\+(\@=')
         if function_name != ""
             call add(compl_words, {'word': function_name . '(',
-                                  \'abbr': function_name,
+                                  \'abbr': function_name, 'info': function_name,
                                   \'kind': 'f'})
         endif
         let lnum = s:ErlangFindNextNonBlank(lnum)
@@ -167,7 +167,7 @@ function s:ErlangFindLocalFunc(base)
         if bif_line =~# base
             let bif_name = substitute(bif_line, '(.*', '(', '')
             call add(compl_words, {'word': bif_name,
-                                   \'abbr': bif_line,
+                                   \'abbr': bif_line, 'info': bif_line,
                                    \'kind': 'f'})
         endif
     endfor

--- a/doc/vim-erlang-omnicomplete.txt
+++ b/doc/vim-erlang-omnicomplete.txt
@@ -4,7 +4,8 @@ CONTENTS                                             *vim-erlang-omnicomplete*
 
     1. Introduction.....................|vim-erlang-omnicomplete-intro|
     2. Credits..........................|vim-erlang-omnicomplete-credits|
-    3. Contributing.....................|vim-erlang-omnicomplete-contributing|
+    3. Opitons..........................|vim-erlang-omnicomplete-options|
+    4. Contributing.....................|vim-erlang-omnicomplete-contributing|
 
 ==============================================================================
 INTRODUCTION                                   *vim-erlang-omnicomplete-intro*
@@ -71,6 +72,38 @@ Contributors: Pawel 'kTT' Salata (http://github.com/kTT)
               Adam Rutkowski <hq@mtod.org>
               Csaba Hoch <csaba.hoch@gmail.com>
 License:      Vim License (see |license|)
+
+==============================================================================
+OPTIONS                                      *vim-erlang-omnicomplete-options*
+
+1. g:erlang_completion_cache
+Allow to cache completion list.Default: 1
+
+2, g:erlang_complete_left_bracket
+Allow completor to add left bracket. Default:1.
+
+When g:erlang_complete_left_bracket = 1, this plugin behave like this:
+
+a, random:seed() -> result in random:seed()
+b, random:seed(SRand) -> result in random:seed(
+c, random:module/0 -> result in random:module()
+d, random:module/1 -> result in random:module(
+
+When g:erlang_complete_left_bracket = 0, this plugin behave like this:
+
+a, random:seed() -> result in random:seed
+b, random:seed(SRand) -> result in random:seed
+c, random:module/0 -> result in random:module
+d, random:module/1 -> result in random:module
+
+This is usefule if you don't want the plugin to complete left bracket, or you
+use some plugin like auto-pairs
+
+3, g:erlang_complete_extend_arbit
+Allow completor to extend "random:module/1" to "randome:module(T1)" in omni's
+Preview window. Default is 0.
+
+==============================================================================
 
 ==============================================================================
 CONTRIBUTING                            *vim-erlang-omnicomplete-contributing*


### PR DESCRIPTION
## Changelog:

- Add function spec to Omni info, so you can get the preview if you want.
- Return `()` instead of `(` if the function doesn't accept any parameter.
- Little improve on local function list, It will provide more results now.

## About the local function list change

Look at the following example:

```
 test(A) ->
    ok.

another_test(A) ->
    ok.
```

In this example, if you list local functions, in the old version, you won't get `test(A)` because its name is not started from the head of that line, so `^\w*` won't match this function and you won't get this function in the return list.

This PR fixed this problem.