### PR TITLE
Make it possible to extend code path with configurable wildcard

### DIFF
--- a/autoload/erlang_complete.erl
+++ b/autoload/erlang_complete.erl
@@ -165,6 +165,12 @@ parse_args(["--basedir", BaseDir|OtherArgs], Acc) ->
 parse_args(["--basedir"], _Acc) ->
     log_error("Argument needed after '--basedir'.~n", []),
     halt(2);
+parse_args(["--extend-code-path-wildcard", BaseDir|OtherArgs], Acc) ->
+    put(extend_code_path_wildcard, BaseDir),
+    parse_args(OtherArgs, Acc);
+parse_args(["--extend-code-path-wildcard"], _Acc) ->
+    log_error("Argument needed after '--extend-code-path-wildcard'.~n", []),
+    halt(2);
 parse_args(["--"|PosPars], Acc) ->
     PosPars ++ Acc;
 parse_args([[$-|_] = Arg|_], _Acc) ->
@@ -295,8 +301,18 @@ load_build_info(Path) ->
     % same as AppRoot).
     ProjectRoot = get_project_root(BuildSystem, BuildFiles, AppRoot),
     BuildSystemOpts = load_build_files(BuildSystem, ProjectRoot, BuildFiles),
-
+    add_code_paths(), 
     {AppRoot, ProjectRoot, BuildSystemOpts}.
+
+add_code_paths() ->
+    case get(extend_code_path_wildcard) of
+        undefined ->
+            ok;
+        "" ->
+            ok;
+        Wildcard ->
+            code:add_pathsa(filelib:wildcard(Wildcard))
+    end.
 
 %%------------------------------------------------------------------------------
 %% @doc Traverse the directory structure upwards until is_app_root matches.

--- a/autoload/erlang_complete.vim
+++ b/autoload/erlang_complete.vim
@@ -4,6 +4,7 @@
 " Contributors: kTT (http://github.com/kTT)
 "               Ricardo Catalinas Jiménez <jimenezrick@gmail.com>
 "               Eduardo Lopez (http://github.com/tapichu)
+"               Kjell Winblad (https://dupwin.se)
 " License:      Vim license
 
 " Completion program path
@@ -47,6 +48,9 @@ if !exists('g:erlang_completion_extend_arity')
     let g:erlang_completion_extend_arity = 1
 end
 
+if !exists('g:erlang_completion_extend_code_path_wildcard')
+    let g:erlang_completion_extend_code_path_wildcard = ""
+end
 " Modules cache used to speed up the completion.
 "
 " This dictionary contains completion items that represent functions exported
@@ -415,7 +419,8 @@ function s:ErlangFindExternalFunc(module, base)
     let compl_words = []
     let output = system('escript ' . fnameescape(s:erlang_complete_file) .
                         \' list-functions ' . fnameescape(a:module) .
-                        \' --basedir ' .  fnameescape(expand('%:p:h')))
+                        \' --basedir ' .  fnameescape(expand('%:p:h')) .
+                        \' --extend-code-path-wildcard ' .  fnameescape(g:erlang_completion_extend_code_path_wildcard))
     let output_lines = split(output, '\n')
 
     " There are two possibilities:
@@ -546,7 +551,8 @@ function s:ErlangFindLocalFunc(base)
     " Find modules that start with `base`.
     let modules = system('escript ' . fnameescape(s:erlang_complete_file) .
                         \' list-modules ' .
-                        \' --basedir ' . fnameescape(expand('%:p:h')))
+                        \' --basedir ' . fnameescape(expand('%:p:h')) .
+                        \' --extend-code-path-wildcard ' .  fnameescape(g:erlang_completion_extend_code_path_wildcard))
     for module in split(modules, '\n')
         if module =~# base
             let compl_item = s:CreateComplItem('module', module)

--- a/doc/vim-erlang-omnicomplete.txt
+++ b/doc/vim-erlang-omnicomplete.txt
@@ -141,7 +141,7 @@ g:erlang_completion_nonzero_arity_paren
 
                list_to_atom(
 <
-g:erlang_completion_extend_arity            g:erlang_completion_extend_arity
+g:erlang_completion_extend_arity            *g:erlang_completion_extend_arity*
         Determines how to display functions where only the arity is known.
 
         a. If set to `0`, such functions will be displayed with their arity,
@@ -155,6 +155,19 @@ g:erlang_completion_extend_arity            g:erlang_completion_extend_arity
                module_info(T1) -> any()
 
 <        The default value is `1`.
+
+                           *g:erlang_completion_extend_code_path_wildcard*
+g:erlang_completion_extend_code_path_wildcard            
+        Specifies a wildcard to be used to extend the code path
+        list that is used when searching for modules. All directories that
+        matches the wildcard will be added to the code path list. See the
+        documentation of the Erlang function `filelib:wildcard/1` for the
+        syntax of wildcards. This option is useful when you have a
+        non-standard directory structure for your Erlang projects.
+
+        Example:
+
+        `let g:erlang_completion_extend_code_path_wildcard = './_build/*/lib/*/ebin'`
 
 ==============================================================================
 CONFIGURATION REBAR3                   *vim-erlang-omnicomplete-config-rebar3*


### PR DESCRIPTION
This PR adds a configuration variable that makes it possible to extend the code path that is used to search for modules. All the directories that matches the wildcard in the variable will be added to the code path. This option is useful when `vim-erlang-omnicomplete` cannot figure out where modules are based on the project structure. For example, the EMQX project (https://github.com/emqx/emqx) uses a fork of rebar3 for building which `vim-erlang-omnicomplete` cannot handle.